### PR TITLE
Fix crypto-key/encryption key issue; fix mutable func parameter

### DIFF
--- a/push_receiver/push_receiver.py
+++ b/push_receiver/push_receiver.py
@@ -55,6 +55,13 @@ FCM_ENDPOINT = 'https://fcm.googleapis.com/fcm/send'
 
 
 def __do_request(req, retries=5):
+  # Enable possibility to use ENV var to disable certificate checking, for debugging etc.
+  URLLIB_VERIFY_CERTIFICATES = os.getenv("URLLIB_VERIFY_CERTIFICATES", "true") == "true"
+  ctx = ssl.create_default_context()
+  if not URLLIB_VERIFY_CERTIFICATES:
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+
   for _ in range(retries):
     try:
       resp = urlopen(req)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("README.rst", "r") as f:
 
 setup(
     name="push_receiver",
-    version="0.1.1",
+    version="0.1.2",
     author="Franc[e]sco",
     author_email="lolisamurai@tfwno.gf",
     url="https://github.com/Francesco149/push_receiver",


### PR DESCRIPTION
Fixes appearing RuntimeError in __app_data_by_key that appears when the function
looks for "crypto-key" or "encryption" in broken FCM messages. These messages are
skipped when the field is not found.
See https://github.com/MatthieuLemoine/push-receiver/issues/21

Also fixes a mutable function parameter, replacing "[]" with None and a check.

Increases patch version.