### PR TITLE
Fix crypto-key/encryption key issue; fix mutable func parameter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("README.rst", "r") as f:
 
 setup(
     name="push_receiver",
-    version="0.1.1",
+    version="0.1.2",
     author="Franc[e]sco",
     author_email="lolisamurai@tfwno.gf",
     url="https://github.com/Francesco149/push_receiver",


### PR DESCRIPTION
Fixes appearing RuntimeError in __app_data_by_key that appears when the function
looks for "crypto-key" or "encryption" in broken FCM messages. These messages are
skipped when the field is not found.
See https://github.com/MatthieuLemoine/push-receiver/issues/21

Also fixes a mutable function parameter, replacing "[]" with None and a check.

Increases patch version.