### PR TITLE
Respond to heartbeat requests, and reestablish connection on disconnect

### DIFF
--- a/push_receiver/push_receiver.py
+++ b/push_receiver/push_receiver.py
@@ -8,6 +8,7 @@
 # For more information, please refer to <http://unlicense.org/>
 
 import struct
+import select
 from .mcs_pb2 import *
 import uuid
 from .checkin_pb2 import AndroidCheckinRequest, AndroidCheckinResponse
@@ -53,6 +54,8 @@ CHECKIN_URL = "https://android.clients.google.com/checkin"
 FCM_SUBSCRIBE = 'https://fcm.googleapis.com/fcm/connect/subscribe'
 FCM_ENDPOINT = 'https://fcm.googleapis.com/fcm/send'
 
+READ_TIMEOUT_SECS = 60 * 60
+MIN_RESET_INTERVAL_SECS = 60 * 5
 
 def __do_request(req, retries=5):
   for _ in range(retries):
@@ -283,6 +286,15 @@ def __send(s, packet):
 
 
 def __recv(s, first=False):
+  try:
+    readable, _, _ = select.select([s,], [], [], READ_TIMEOUT_SECS)
+    if len(readable) == 0:
+      __log.debug("Select read timeout")
+      return None
+  except select.error:
+    __log.debug("Select error")
+    return None
+  __log.debug("Data available to read")
   if first:
     version, tag = struct.unpack("BB", __read(s, 2))
     __log.debug("version {}".format(version))
@@ -313,12 +325,19 @@ def __app_data_by_key(p, key, blow_shit_up=True):
   return None
 
 
-def __listen(s, credentials, callback, persistent_ids, obj):
-  import http_ece
-  import cryptography.hazmat.primitives.serialization as serialization
-  from cryptography.hazmat.backends import default_backend
-  load_der_private_key = serialization.load_der_private_key
+def __open():
+  import socket
+  import ssl
+  HOST = "mtalk.google.com"
+  context = ssl.create_default_context()
+  sock = socket.create_connection((HOST, 5228))
+  s = context.wrap_socket(sock, server_hostname=HOST)
+  __log.debug("connected to ssl socket")
+  return s
 
+
+def __login(credentials, persistent_ids):
+  s = __open()
   gcm_check_in(**credentials["gcm"])
   req = LoginRequest()
   req.adaptive_heartbeat = False
@@ -335,28 +354,77 @@ def __listen(s, credentials, callback, persistent_ids, obj):
   req.received_persistent_id.extend(persistent_ids)
   __send(s, req)
   login_response = __recv(s, first=True)
+  __log.info(f'Received login response:\n{login_response}')
+  return s
+
+
+last_reset = 0
+def __reset(s, credentials, persistent_ids):
+  global last_reset
+  now = time.time()
+  if (now - last_reset < MIN_RESET_INTERVAL_SECS):
+    raise Exception("Too many connection reset attempts.")
+  last_reset = now
+  __log.debug("Reestablishing connection")
+  s.shutdown(2)
+  s.close()
+  return __login(credentials, persistent_ids)
+
+
+def __listen(credentials, callback, persistent_ids, obj):
+  s = __login(credentials, persistent_ids)
   while True:
-    p = __recv(s)
-    if type(p) is not DataMessageStanza:
-      continue
-    crypto_key = __app_data_by_key(p, "crypto-key")[3:]  # strip dh=
-    salt = __app_data_by_key(p, "encryption")[5:]  # strip salt=
-    crypto_key = urlsafe_b64decode(crypto_key.encode("ascii"))
-    salt = urlsafe_b64decode(salt.encode("ascii"))
-    der_data = credentials["keys"]["private"]
-    der_data = urlsafe_b64decode(der_data.encode("ascii") + b"========")
-    secret = credentials["keys"]["secret"]
-    secret = urlsafe_b64decode(secret.encode("ascii") + b"========")
-    privkey = load_der_private_key(
-        der_data, password=None, backend=default_backend()
-    )
-    decrypted = http_ece.decrypt(
-        p.raw_data, salt=salt,
-        private_key=privkey, dh=crypto_key,
-        version="aesgcm",
-        auth_secret=secret
-    )
-    callback(obj, json.loads(decrypted.decode("utf-8")), p)
+    try:
+      p = __recv(s)
+      if type(p) is DataMessageStanza:
+        id = __handle_data_message(p, credentials, callback, obj)
+        persistent_ids.append(id)
+      elif type(p) is HeartbeatPing:
+        __handle_ping(s, p)
+      elif p == None or type(p) is Close:
+        s = __reset(s, credentials, persistent_ids)
+      else:
+        __log.debug(f'Unexpected message type {type(p)}.')
+    except ConnectionResetError:
+      __log.debug("Connection Reset: Reconnecting")
+      s = __reset(s, credentials, persistent_ids)
+
+
+def __handle_data_message(p, credentials, callback, obj):
+  import http_ece
+  import cryptography.hazmat.primitives.serialization as serialization
+  from cryptography.hazmat.backends import default_backend
+  load_der_private_key = serialization.load_der_private_key
+
+  crypto_key = __app_data_by_key(p, "crypto-key")[3:]  # strip dh=
+  salt = __app_data_by_key(p, "encryption")[5:]  # strip salt=
+  crypto_key = urlsafe_b64decode(crypto_key.encode("ascii"))
+  salt = urlsafe_b64decode(salt.encode("ascii"))
+  der_data = credentials["keys"]["private"]
+  der_data = urlsafe_b64decode(der_data.encode("ascii") + b"========")
+  secret = credentials["keys"]["secret"]
+  secret = urlsafe_b64decode(secret.encode("ascii") + b"========")
+  privkey = load_der_private_key(
+      der_data, password=None, backend=default_backend()
+  )
+  decrypted = http_ece.decrypt(
+      p.raw_data, salt=salt,
+      private_key=privkey, dh=crypto_key,
+      version="aesgcm",
+      auth_secret=secret
+  )
+  __log.info(f'Received data message {p.persistent_id}: {decrypted}')
+  callback(obj, json.loads(decrypted.decode("utf-8")), p)
+  return p.persistent_id
+
+
+def __handle_ping(s, p):
+  __log.debug(f'Responding to ping: Stream ID: {p.stream_id}, Last: {p.last_stream_id_received}, Status: {p.status}')
+  req = HeartbeatAck()
+  req.stream_id = p.stream_id + 1
+  req.last_stream_id_received = p.stream_id
+  req.status = p.status
+  __send(s, req)
 
 
 def listen(credentials, callback, received_persistent_ids=[], obj=None):
@@ -369,17 +437,7 @@ def listen(credentials, callback, received_persistent_ids=[], obj=None):
                            array of strings
   obj: optional arbitrary value passed to callback
   """
-  import socket
-  import ssl
-  HOST = "mtalk.google.com"
-  context = ssl.create_default_context()
-  sock = socket.create_connection((HOST, 5228))
-  s = context.wrap_socket(sock, server_hostname=HOST)
-  __log.debug("connected to ssl socket")
-  __listen(s, credentials, callback, received_persistent_ids, obj)
-  s.close()
-  sock.close()
-
+  __listen(credentials, callback, received_persistent_ids, obj)
 
 def run_example():
   """sample that registers a token and waits for notifications"""

--- a/push_receiver/push_receiver.py
+++ b/push_receiver/push_receiver.py
@@ -366,8 +366,11 @@ def __reset(s, credentials, persistent_ids):
     raise Exception("Too many connection reset attempts.")
   last_reset = now
   __log.debug("Reestablishing connection")
-  s.shutdown(2)
-  s.close()
+  try:
+    s.shutdown(2)
+    s.close()
+  except OSError as e:
+    __log.debug(f"Unable to close connection {e}")  
   return __login(credentials, persistent_ids)
 
 
@@ -387,7 +390,7 @@ def __listen(credentials, callback, persistent_ids, obj):
         __log.debug(f'Unexpected message type {type(p)}.')
     except ConnectionResetError:
       __log.debug("Connection Reset: Reconnecting")
-      s = __reset(s, credentials, persistent_ids)
+      s = __login(credentials, persistent_ids)
 
 
 def __handle_data_message(p, credentials, callback, obj):

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("README.rst", "r") as f:
 
 setup(
     name="push_receiver",
-    version="0.1.1",
+    version="0.2.0",
     author="Franc[e]sco",
     author_email="lolisamurai@tfwno.gf",
     url="https://github.com/Francesco149/push_receiver",


### PR DESCRIPTION
This likely deserves some editing, since I am not a Python guy or a FCM guy.  However, it does respond to heartbeat requests, and reestablishes the connection when it is closed or fails.  I've tested it for a few days in my environment (using for a Raspberry Pi project), and it works correctly there.